### PR TITLE
Feature/OpenAI

### DIFF
--- a/controllers/ai.controller.js
+++ b/controllers/ai.controller.js
@@ -7,9 +7,9 @@ const aiController = {};
 
 aiController.getMealFeedback = async (req, res) => {
   try {
-    const meals = req.meals; // loadMeals 미들웨어에서 세팅됨
+    const meals = req.meals;
     const userId = req.userId;
-    const mode = req.mode; // daily | weekly
+    const { date, mode = "daily", type } = req.query;
 
     // 유저 목표 가져오기
     const user = await User.findById(userId);
@@ -18,21 +18,85 @@ aiController.getMealFeedback = async (req, res) => {
       goalWeight: user.goalWeight,
     };
 
-    // 1. AI에게 피드백 요청
-    const feedbackText = await aiService.getMealFeedback(meals, goals, mode);
+    // filteredMeals: daily 모드일 때 type 필터 적용
+    let filteredMeals = meals;
+    if (mode === "daily" && type) {
+      filteredMeals = meals.filter((meal) => meal.type === type);
+    }
 
-    // 2. 응답 텍스트 파싱
+    // -----------------------------
+    // 중복 피드백 확인 및 저장할 날짜 계산
+    let feedbackDate;
+    let existingFeedback;
+    if (mode === "daily") {
+      feedbackDate = date ? new Date(date) : new Date();
+      feedbackDate.setHours(0, 0, 0, 0); // 하루 시작일 기준
+
+      const endOfDay = new Date(feedbackDate);
+      endOfDay.setHours(23, 59, 59, 999);
+
+      existingFeedback = await MealFeedback.findOne({
+        userId,
+        mode,
+        date: { $gte: feedbackDate, $lte: endOfDay },
+      });
+    } else if (mode === "weekly") {
+      const today = new Date();
+      const dayOfWeek = today.getDay(); // 일요일=0
+      feedbackDate = new Date(today);
+      feedbackDate.setDate(today.getDate() - dayOfWeek); // 주 시작일
+      feedbackDate.setHours(0, 0, 0, 0);
+
+      const weekEnd = new Date(feedbackDate);
+      weekEnd.setDate(weekEnd.getDate() + 6);
+      weekEnd.setHours(23, 59, 59, 999);
+
+      const existingFeedbackWeekly = await MealFeedback.findOne({
+        userId,
+        mode,
+        date: { $gte: feedbackDate, $lte: weekEnd },
+      });
+
+      if (existingFeedbackWeekly) {
+        return res.status(409).json({
+          status: "fail",
+          message: "기존 피드백이 존재합니다.",
+        });
+      }
+    }
+
+    // AI 피드백 요청
+    const feedbackText = await aiService.getMealFeedback(
+      filteredMeals,
+      goals,
+      mode
+    );
+
+    // 응답 텍스트 파싱
     const parsed = parseFeedback(feedbackText);
 
-    // 3. DB에 저장
+    if (mode === "daily" && existingFeedback) {
+      existingFeedback.mealIds = filteredMeals.map((m) => m._id);
+      existingFeedback.feedback = parsed;
+      existingFeedback.updatedAt = new Date();
+      await existingFeedback.save();
+
+      return res.status(200).json({
+        status: "success",
+        message: "기존 피드백이 최신 내용으로 갱신되었습니다.",
+        feedback: existingFeedback,
+      });
+    }
+
+    // DB 저장 (mode/daily/weekly 기준 date 사용)
     const feedbackDoc = await MealFeedback.create({
       userId,
-      mealIds: meals.map((m) => m._id),
+      mealIds: filteredMeals.map((m) => m._id),
       mode,
+      date: feedbackDate,
       feedback: parsed,
     });
 
-    // 4. 응답
     res.status(200).json({ status: "success", feedback: feedbackDoc });
   } catch (error) {
     res.status(500).json({ status: "fail", error: error.message });
@@ -42,23 +106,69 @@ aiController.getMealFeedback = async (req, res) => {
 aiController.getUserMealFeedback = async (req, res) => {
   try {
     const userId = req.userId;
-    const { mode, date } = req.query;
+    const { mode = "daily", date, type } = req.query;
 
-    const query = { userId };
-    if (mode) query.mode = mode;
-    if (date) {
-      const start = new Date(date);
-      start.setHours(0, 0, 0, 0);
-      const end = new Date(date);
-      end.setHours(23, 59, 59, 999);
-      query.createdAt = { $gte: start, $lte: end };
+    let feedbacks;
+
+    if (mode === "daily") {
+      if (!date) {
+        return res.status(400).json({
+          status: "fail",
+          message: "daily 모드에서는 date 값이 필요합니다.",
+        });
+      }
+
+      const startOfDay = new Date(date);
+      startOfDay.setHours(0, 0, 0, 0);
+      const endOfDay = new Date(date);
+      endOfDay.setHours(23, 59, 59, 999);
+
+      const query = {
+        userId,
+        mode,
+        date: { $gte: startOfDay, $lte: endOfDay },
+      };
+      if (type) query["feedback.type"] = type; // feedback 내부에 type 저장했을 경우
+
+      feedbacks = await MealFeedback.find(query);
+    } else if (mode === "weekly") {
+      if (!date) {
+        return res.status(400).json({
+          status: "fail",
+          message: "weekly 모드에서는 date 값이 필요합니다.",
+        });
+      }
+
+      const targetDate = new Date(date);
+      const dayOfWeek = targetDate.getDay();
+      const startOfWeek = new Date(targetDate);
+      startOfWeek.setDate(targetDate.getDate() - dayOfWeek);
+      startOfWeek.setHours(0, 0, 0, 0);
+
+      const endOfWeek = new Date(startOfWeek);
+      endOfWeek.setDate(endOfWeek.getDate() + 6);
+      endOfWeek.setHours(23, 59, 59, 999);
+
+      feedbacks = await MealFeedback.find({
+        userId,
+        mode,
+        date: { $gte: startOfWeek, $lte: endOfWeek },
+      });
+    } else {
+      return res
+        .status(400)
+        .json({ status: "fail", message: "유효하지 않은 mode 값입니다." });
     }
 
-    const feedbacks = await MealFeedback.find(query).sort({ createdAt: -1 });
+    if (!feedbacks || feedbacks.length === 0) {
+      return res
+        .status(404)
+        .json({ status: "fail", message: "피드백이 존재하지 않습니다." });
+    }
+
     res.status(200).json({ status: "success", feedbacks });
   } catch (error) {
     res.status(500).json({ status: "fail", error: error.message });
   }
 };
-
 export default aiController;

--- a/models/MealFeedback.js
+++ b/models/MealFeedback.js
@@ -10,6 +10,7 @@ const MealFeedbackSchema = new Schema(
     },
     mealIds: [{ type: mongoose.Schema.Types.ObjectId, ref: "Meal" }], // 연결된 식단(하루 또는 일주일치)
     mode: { type: String, enum: ["daily", "weekly"], required: true },
+    date: { type: Date, default: null }, // 피드백 생성 시 기본값 null, 필수 아님
     feedback: {
       nutritionBalance: { type: String }, // 영양 밸런스 평가
       goodPoints: { type: String }, // 잘하고 있는 점


### PR DESCRIPTION
식단 피드백 생성, 조회 기능을 수정했습니다.

1. mode=daily인 경우 생성하실 때 
예시) /api/openai/feedback?mode=daily&date=2025-08-28 
이런식으로 mode와 date를 쿼리에 보내주시면 생성됩니다. 
(type은 안 넣어도 됩니다. daily모드는 데이터가 계속 업데이트 되도록 했습니다.)
get으로 요청하실 때도 똑같이 하시면 됩니다.

2. mode=weekly인 경우 생성하실 때
예시) /api/openai/feedback?mode=weekly 
date 없이 mode만 보내주시면 됩니다. 월요일을 한 주의 시작으로 설정했습니다.
get 요청하실 때는 
예시) /api/openai/feedback?mode=weekly&date=2025-08-29
날짜는 해당 주의 월요일에서 일요일까지 아무 날짜를 기입하면 해당 주의 주간 피드백이 나옵니다.

